### PR TITLE
Fixed a problem of inclusion of stdlib.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.63.0 COMPONENTS filesystem date_time)
+find_package(Boost 1.58.0 COMPONENTS filesystem date_time)
 
 if (Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})

--- a/Pin/Pin.h
+++ b/Pin/Pin.h
@@ -6,6 +6,7 @@
 #define WPS_PIN_GENERATOR_PIN_H
 
 #include <string>
+#include <stdlib.h>
 
 /**
  * Class Pin
@@ -23,7 +24,7 @@ public:
 	 * @param pin
 	 */
 	Pin(const std::string &pin) {
-		this->pinValue = atoi(pin.c_str());
+		this->pinValue = std::atoi(pin.c_str());
 		this->valid();
 	}
 
@@ -45,7 +46,8 @@ public:
 	 * Returns pin using a string
 	 * @return string of pin
 	 */
-	std::string toString() const { return std::to_string(pinValue); }
+	std::string toString() const {
+		return std::to_string(pinValue); }
 
 	/**
 	 * Returns pin using a long integer

--- a/Pin/Pin.h
+++ b/Pin/Pin.h
@@ -46,8 +46,7 @@ public:
 	 * Returns pin using a string
 	 * @return string of pin
 	 */
-	std::string toString() const {
-		return std::to_string(pinValue); }
+	std::string toString() const { return std::to_string(pinValue); }
 
 	/**
 	 * Returns pin using a long integer


### PR DESCRIPTION
A method in the class Pin uses the method std::atoi which is found in std::basic_string. This class is available including "stdlib.h". Using both g++ (6.3.1) and cmake with the c++11 standard it works ok, but @FightingForFun reported an error in Ubuntu 16.04 saying atoi is not defined.
I've now included stdlib.h in that class so it should not give that error anymore.